### PR TITLE
fix logout for django 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 */*/*/*.pyc
 /db.sqlite3
 root/*
+version.env
 /bellettrie_library_system/settings_production.py
 bellettrie_library_system/.env
 static/images/logo.png

--- a/bellettrie_library_system/base_settings.py
+++ b/bellettrie_library_system/base_settings.py
@@ -15,6 +15,7 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 from django.urls import reverse
 
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 RESERVATION_TIMEOUT_DAYS = 14
@@ -143,7 +144,7 @@ def GET_MENU():
     my_menu.append(MenuItem('Contact', reverse('named_page', args=('basic', 'contact',)), None, 'top-right', [], icon='fa fa-info'))
 
     my_menu.append(MenuItem('Login', reverse('login'), None, 'top-right', [], anonymous=True, icon='fa fa-sign-in-alt'))
-    my_menu.append(MenuItem('Logout', reverse('logout'), None, 'top-right', [], anonymous=False, icon='fa fa-sign-out-alt'))
+    my_menu.append(MenuItem('Logout', reverse('logout'), None, 'top-right', [], anonymous=False, icon='fa fa-sign-out-alt', is_logout=True))
 
     my_menu.append(MenuItem('Catalog', reverse('works.list'), None, 'sidebar', [], anonymous=False, icon='fa fa-book'))
     my_menu.append(MenuItem('Members', reverse('members.list'), 'members.view_member', 'sidebar', [], anonymous=None, icon='fa fa-user'))

--- a/config/menu.py
+++ b/config/menu.py
@@ -2,10 +2,9 @@ from django.shortcuts import render
 from django.urls import reverse
 
 
-
-
 class MenuItem:
-    def __init__(self, title, url, permission, location, sub_items, anonymous=None, only_subitems=False, icon=None, is_logout=False):
+    def __init__(self, title, url, permission, location, sub_items, anonymous=None, only_subitems=False, icon=None,
+                 is_logout=False):
         self.title = title
         self.url = url
         self.permission = permission
@@ -17,8 +16,9 @@ class MenuItem:
         self.is_logout = is_logout
 
     def permits(self, request):
-        return (self.permission is None or request.user.has_perm(self.permission)) and (self.anonymous is None or request.user.is_anonymous == self.anonymous) and (
-            not self.only_subitems or len(self.rendered_sub_items(request)) > 0)
+        return (self.permission is None or request.user.has_perm(self.permission)) and (
+                    self.anonymous is None or request.user.is_anonymous == self.anonymous) and (
+                not self.only_subitems or len(self.rendered_sub_items(request)) > 0)
 
     def rendered_sub_items(self, request):
         lst = []
@@ -30,7 +30,8 @@ class MenuItem:
 
     def render(self, request):
         sub_items = self.rendered_sub_items(request)
-        return render(request, 'config/render_menu_item.html', context={'menu': self, 'has_sub_items': len(sub_items) > 0, 'sub_items': sub_items})
+        return render(request, 'config/render_menu_item.html',
+                      context={'menu': self, 'has_sub_items': len(sub_items) > 0, 'sub_items': sub_items})
 
     def get_title_shortened(self):
         return self.title.replace(" ", "")

--- a/config/menu.py
+++ b/config/menu.py
@@ -2,8 +2,10 @@ from django.shortcuts import render
 from django.urls import reverse
 
 
+
+
 class MenuItem:
-    def __init__(self, title, url, permission, location, sub_items, anonymous=None, only_subitems=False, icon=None):
+    def __init__(self, title, url, permission, location, sub_items, anonymous=None, only_subitems=False, icon=None, is_logout=False):
         self.title = title
         self.url = url
         self.permission = permission
@@ -12,6 +14,7 @@ class MenuItem:
         self.anonymous = anonymous
         self.only_subitems = only_subitems
         self.icon = icon
+        self.is_logout = is_logout
 
     def permits(self, request):
         return (self.permission is None or request.user.has_perm(self.permission)) and (self.anonymous is None or request.user.is_anonymous == self.anonymous) and (
@@ -19,6 +22,7 @@ class MenuItem:
 
     def rendered_sub_items(self, request):
         lst = []
+
         for item in self.sub_items:
             if item.permits(request):
                 lst.append(item)

--- a/config/menu.py
+++ b/config/menu.py
@@ -16,9 +16,10 @@ class MenuItem:
         self.is_logout = is_logout
 
     def permits(self, request):
-        return (self.permission is None or request.user.has_perm(self.permission)) and (
-                    self.anonymous is None or request.user.is_anonymous == self.anonymous) and (
-                not self.only_subitems or len(self.rendered_sub_items(request)) > 0)
+        return ((self.permission is None or request.user.has_perm(self.permission))
+                and (self.anonymous is None or request.user.is_anonymous == self.anonymous)
+                and (not self.only_subitems or len(self.rendered_sub_items(request)) > 0)
+                )
 
     def rendered_sub_items(self, request):
         lst = []

--- a/config/templates/config/render_logout.html
+++ b/config/templates/config/render_logout.html
@@ -1,6 +1,6 @@
 {% load menu %}
 <style>
-    .fakeURL {
+    .renderLogoutfakeURL {
         display: inline-block;
         vertical-align: top;
         line-height: 0px;
@@ -15,7 +15,7 @@
         color: grey;
     }
 
-    .formstyle {
+    .renderLogoutformstyle {
         display: inline-block;
         vertical-align: top;
         margin-top: -40px;
@@ -25,9 +25,9 @@
 
 
 {% if mode == 'desktop-top' %}
-    <form method="post" action="{% url 'logout' %}" class="formstyle">
+    <form method="post" action="{% url 'logout' %}" class="renderLogoutformstyle">
         {% csrf_token %}
-        <input class="btn btn-outline fakeURL" type="submit" value="{{ menu.title }}"
+        <input class="btn btn-outline renderLogoutfakeURL" type="submit" value="{{ menu.title }}"
                style="">
     </form>
 {% endif %}
@@ -35,7 +35,7 @@
     <form method="post" action="{% url 'logout' %}">
         {% csrf_token %}
         <li class="treeview hiddenDesktop">
-            <input class="btn btn-link" type="submit" class="" value="{{ menu.title }}">
+            <input class="btn btn-link" type="submit"  value="{{ menu.title }}">
         </li>
     </form>
 {% endif %}

--- a/config/templates/config/render_logout.html
+++ b/config/templates/config/render_logout.html
@@ -1,0 +1,41 @@
+{% load menu %}
+<style>
+    .fakeURL {
+        display: inline-block;
+        vertical-align: top;
+        line-height: 0px;
+        whitespace: no-wrap;
+        font-family: 'Rubik', sans-serif;
+        margin-left: .1vw;
+        border-left: .1vw solid black;
+        padding-left: .1vw;
+        margin-top: 25px;
+        height: 30px;
+        font-size: 1vw;
+        color: grey;
+    }
+
+    .formstyle {
+        display: inline-block;
+        vertical-align: top;
+        margin-top: -40px;
+    }
+
+</style>
+
+
+{% if mode == 'desktop-top' %}
+    <form method="post" action="{% url 'logout' %}" class="formstyle">
+        {% csrf_token %}
+        <input class="btn btn-outline fakeURL" type="submit" value="{{ menu.title }}"
+               style="">
+    </form>
+{% endif %}
+{% if mode == 'mobile-only' %}
+    <form method="post" action="{% url 'logout' %}">
+        {% csrf_token %}
+        <li class="treeview hiddenDesktop">
+            <input class="btn btn-link" type="submit" class="" value="{{ menu.title }}">
+        </li>
+    </form>
+{% endif %}

--- a/config/templates/config/render_menu_item.html
+++ b/config/templates/config/render_menu_item.html
@@ -1,11 +1,20 @@
 {% load menu %}
 {% if mode == 'desktop-top' %}
-    <a href="{{ menu.url }}" class="vertical hiddenMobile">{{ menu.title }}</a>
+    {% if menu.is_logout %}
+{% include 'config/render_logout.html' %}
+    {% else %}
+        <a href="{{ menu.url }}" class="vertical hiddenMobile">{{ menu.title }}</a>
+    {% endif %}
 {% endif %}
 {% if mode == 'mobile-only' %}
-    <li class="treeview hiddenDesktop"><a href="{{ menu.url }}">
-        <i class="{{ menu.icon }}"></i><span>{{ menu.title }}</span>
-    </a></li>
+    <li class="treeview hiddenDesktop">
+        {% if menu.is_logout %}
+        {% include 'config/render_logout.html' %}
+        {% else %}
+            <a href="{{ menu.url }}">
+                <i class="{{ menu.icon }}"></i><span>{{ menu.title }}</span>
+            </a>
+        {% endif %}</li>
 {% endif %}
 
 {% if mode == 'sidebar-item' %}


### PR DESCRIPTION
Django 5.x deprecates allowing logout through GET requests (due to security concerns). In this MR, the logout links are replaced by inline forms, which look as much like links as I could get them to look.

We may want to take this into account if/when we redesign the outer shell of the site.