### PR TITLE
Register Committee model in admin.py

### DIFF
--- a/members/admin.py
+++ b/members/admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
 
 # Register your models here.
-from members.models import Member, MemberBackground, MembershipType
+from members.models import Member, MemberBackground, MembershipType, Committee
 
 admin.site.register(Member)
 admin.site.register(MemberBackground)
 admin.site.register(MembershipType)
+admin.site.register(Committee)


### PR DESCRIPTION
Added the Committee model to admin.py in the members module so that it can be managed through the Django admin interface. Fixes #624 