### PR TITLE
Fix search query handling for apostrophes

### DIFF
--- a/utils/get_query_words.py
+++ b/utils/get_query_words.py
@@ -1,6 +1,7 @@
 def get_query_words(query):
     if query is None:
         return None
+    query = query.replace("'", " ")
     p_words = query.split(" ")
     words = []
     for word in p_words:


### PR DESCRIPTION
  Replace apostrophes with spaces in search queries to match the
  behavior of the indexing system. This fixes issue #754 where
  searching for terms like 'd'une' would not return expected results.

  The indexing system (get_words_in_str) already converts apostrophes
  to spaces, but the query parsing (get_query_words) did not, causing
  a mismatch between indexed data and search queries.

  Fixes #754