### PR TITLE
Fix button text in committee removal modal

### DIFF
--- a/members/templates/members/modals/committee_leave.html
+++ b/members/templates/members/modals/committee_leave.html
@@ -6,7 +6,7 @@
             Are you sure you want to do this?
         {% endfill %}
         {% fill "modal_submit_button" %}
-            <button class="btn btn-error  join-item">Delete</button>
+            <button class="btn btn-error  join-item">Remove</button>
         {% endfill %}
     {% endcomponent %}
 {% endblock %}


### PR DESCRIPTION
  Change button text from 'Delete' to 'Remove' in the committee
  leave modal to better reflect the action being performed.
  Removing a member from a committee is different from deleting
  them entirely, so the button should say 'Remove'.

  Fixes #752